### PR TITLE
Fix swapfree and memfree checks. 

### DIFF
--- a/check_d42_health.pl
+++ b/check_d42_health.pl
@@ -166,7 +166,7 @@ $data_val =~s/ MB|GB//ig if ($plugin->opts->item eq 'dbsize');
 if ($plugin->opts->item eq 'memfree') {
 
     # -- assign back to data_val parameter and then compare with the thresholds
-    $data_val = 100 - getPercentage('memtotal',$data_val);
+    $data_val = getPercentage('memtotal',$data_val);
 }
 
 # --
@@ -214,13 +214,17 @@ $plugin->nagios_exit(UNKNOWN, "Item " . $plugin->opts->item . " is empty or not 
 
 # -- prepare default output message for all checks
 my $output_val = $data_val;
-if($plugin->opts->item eq 'swapfree' or $plugin->opts->item eq 'memfree') {
+if($plugin->opts->item eq 'swapfree') { 
     $output_val = 100-$data_val;
 }
 my $output_text = $plugin->opts->item . " = " . $output_val;
 
 # -- set thresholds
-$plugin->set_thresholds(warning => $plugin->opts->warning, critical => $plugin->opts->critical);
+if($plugin->opts->item eq 'memfree') { 
+	$plugin->set_thresholds(warning => (100 - $plugin->opts->warning), critical => (100 - $plugin->opts->critical));
+} else {
+	$plugin->set_thresholds(warning => $plugin->opts->warning, critical => $plugin->opts->critical);
+}
 
 # -- compare thresholds
 if ($plugin->opts->warning || $plugin->opts->critical) {

--- a/check_d42_health.pl
+++ b/check_d42_health.pl
@@ -166,13 +166,13 @@ $data_val =~s/ MB|GB//ig if ($plugin->opts->item eq 'dbsize');
 if ($plugin->opts->item eq 'memfree') {
 
     # -- assign back to data_val parameter and then compare with the thresholds
-    $data_val = getPercentage('memtotal',$data_val);
+    $data_val = 100 - getPercentage('memtotal',$data_val);
 }
 
 # --
 if ($plugin->opts->item eq 'swapfree') {
     # -- assign back to data_val parameter and then compare with the thresholds
-    $data_val = getPercentage('swaptotal', $data_val);
+    $data_val = 100 - getPercentage('swaptotal', $data_val);
 }
 
 
@@ -210,10 +210,14 @@ if ($plugin->opts->item eq 'backup_status') {
     }
 }
 
-$plugin->nagios_exit(UNKNOWN, "Item " . $plugin->opts->item . " is empty or not defined") unless $data_val;
+$plugin->nagios_exit(UNKNOWN, "Item " . $plugin->opts->item . " is empty or not defined") unless defined($data_val);
 
 # -- prepare default output message for all checks
-my $output_text = $plugin->opts->item . " = " . $data_val;
+my $output_val = $data_val;
+if($plugin->opts->item eq 'swapfree' or $plugin->opts->item eq 'memfree') {
+    $output_val = 100-$data_val;
+}
+my $output_text = $plugin->opts->item . " = " . $output_val;
 
 # -- set thresholds
 $plugin->set_thresholds(warning => $plugin->opts->warning, critical => $plugin->opts->critical);


### PR DESCRIPTION
Update check_42_health.pl to check swapfree and memfree usage
properly against the numbers provided for warning and critical.

This is basically used to do a "less than provided numbers" check
instead of a "greater than provided numbers" check.
